### PR TITLE
Fix start script path

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Use Node.js 20
-export PATH="/Users/harryscott/.nvm/versions/node/v20.19.2/bin:$PATH"
+# Use system Node.js (requires Node 18+)
+# Remove hard-coded path so the script works on any machine
 
 # Install dependencies if node_modules doesn't exist
 if [ ! -d "node_modules" ]; then


### PR DESCRIPTION
## Summary
- make `start.sh` use the user's PATH instead of a hard‑coded nvm location

## Testing
- `npm install`
- `npm run lint` *(fails: module is not defined in ES module scope)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68475a1a08308328843198f040eaf6d0