### PR TITLE
fix: use ESM Recharts modules

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ import {
   TrendingDown
 } from 'lucide-react'; 
 
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts/es6';
 import {
   auth,
   onAuthStateChanged,

--- a/src/components/TokenomicsUI.jsx
+++ b/src/components/TokenomicsUI.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { TrendingUp, TrendingDown, Search, Filter, DollarSign, Users, Award, Shuffle, X, History, ShoppingCart, Link, Store, Instagram, Settings, PlusCircle, CreditCard, Calendar, TrendingUpIcon, LogIn, LogOut } from 'lucide-react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts/es6';
 
 // Firebase imports
 import {


### PR DESCRIPTION
## Summary
- import Recharts components from the ESM build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68476ec9e9bc83288ed141f659ec8332