### PR TITLE
Fix Vercel app stylesheet resolution

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import DeploymentMarker from './DeploymentMarker.jsx'
+import './app.css'
 import './styles.css'
 import './closure-tokenomics.css'
 


### PR DESCRIPTION
Import the Black Mirror application stylesheet from the Vite entry point so the deployment snapshot resolves it before rendering App. This also forces a fresh deployment containing both App.jsx and src/app.css.