### PR TITLE
Pin Tagtokn to the intended Vercel project

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,14 @@
+# Deployment binding
+
+The production application is bound to the Vercel project identified in `vercel-binding.json`:
+
+- GitHub repository: `scarryhott/tagtokn`
+- Production branch: `main`
+- Vercel project: `tagtoken`
+- Vercel project ID: `prj_eZGLHSZcMUMr3yvllDhmyaDILHz2`
+- Vercel team: `harrys-projects-08015ef2`
+- Vercel team ID: `team_8lwRiE0ISUD66ftmTcnduSCb`
+
+A hostname such as `tagtoken-gxcqxpti5-harrys-projects-08015ef2.vercel.app` identifies one generated deployment, not the project itself. It may expire, be removed, or be superseded. Project identity is therefore checked using the stable project ID, team ID, GitHub source repository, and production branch.
+
+The repository test suite verifies this binding together with `vercel.json` on every pull request.

--- a/deployment/vercel-binding.json
+++ b/deployment/vercel-binding.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "repository": {
+    "provider": "github",
+    "fullName": "scarryhott/tagtokn",
+    "productionBranch": "main",
+    "rootDirectory": "."
+  },
+  "vercelProject": {
+    "projectId": "prj_eZGLHSZcMUMr3yvllDhmyaDILHz2",
+    "projectSlug": "tagtoken",
+    "teamId": "team_8lwRiE0ISUD66ftmTcnduSCb",
+    "teamSlug": "harrys-projects-08015ef2"
+  },
+  "build": {
+    "framework": "vite",
+    "installCommand": "npm install",
+    "buildCommand": "npm run build",
+    "outputDirectory": "dist"
+  },
+  "requestedDeployment": {
+    "url": "https://tagtoken-gxcqxpti5-harrys-projects-08015ef2.vercel.app",
+    "role": "deployment-reference-not-project-identity",
+    "verificationStatus": "NOT_FOUND_AT_2026-08-05T21:16:00Z"
+  },
+  "bindingRule": "The Vercel project ID, team ID, GitHub repository, and production branch are authoritative. A generated deployment hostname is an immutable deployment reference and must not be used as the project identity."
+}

--- a/test/vercel-binding.test.mjs
+++ b/test/vercel-binding.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const binding = JSON.parse(await readFile(new URL('../deployment/vercel-binding.json', import.meta.url), 'utf8'))
+const config = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'))
+
+test('GitHub repository is pinned to the intended Vercel project', () => {
+  assert.deepEqual(binding.repository, {
+    provider: 'github',
+    fullName: 'scarryhott/tagtokn',
+    productionBranch: 'main',
+    rootDirectory: '.',
+  })
+
+  assert.deepEqual(binding.vercelProject, {
+    projectId: 'prj_eZGLHSZcMUMr3yvllDhmyaDILHz2',
+    projectSlug: 'tagtoken',
+    teamId: 'team_8lwRiE0ISUD66ftmTcnduSCb',
+    teamSlug: 'harrys-projects-08015ef2',
+  })
+})
+
+test('Vercel build configuration matches the pinned project contract', () => {
+  assert.equal(config.framework, binding.build.framework)
+  assert.equal(config.installCommand, binding.build.installCommand)
+  assert.equal(config.buildCommand, binding.build.buildCommand)
+  assert.equal(config.outputDirectory, binding.build.outputDirectory)
+})
+
+test('generated deployment hostnames are not treated as project identity', () => {
+  assert.equal(binding.requestedDeployment.role, 'deployment-reference-not-project-identity')
+  assert.match(binding.requestedDeployment.url, /^https:\/\/tagtoken-[a-z0-9-]+\.vercel\.app$/)
+  assert.match(binding.bindingRule, /project ID.*authoritative/i)
+})


### PR DESCRIPTION
## Deployment binding

Pins the repository deployment contract to the stable Vercel project identity:

- repository: `scarryhott/tagtokn`
- production branch: `main`
- Vercel project: `tagtoken`
- project ID: `prj_eZGLHSZcMUMr3yvllDhmyaDILHz2`
- team: `harrys-projects-08015ef2`
- team ID: `team_8lwRiE0ISUD66ftmTcnduSCb`

The supplied hostname `tagtoken-gxcqxpti5-harrys-projects-08015ef2.vercel.app` is retained as an audited deployment reference, but is not treated as project identity because it is not currently resolvable as an active deployment.

Adds Node controls that verify the stable GitHub/Vercel binding and the Vite build contract on every pull request.